### PR TITLE
stdin: add stdin for the input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,5 @@ $ pulpMd --target=input.md --output=output.md
 --fileExt   (-e): Extension list.  Can be used to filter "js,go,java" or used to specify the markdown code identifier "aspx:asp".
 --notags    (-n): Leave snippet tags in output.  [To facilitate multiple-pass processing]
 --quotes    (-q): Leave block quotes in output when no code was inserted in the following tag.  [Default cleans up block-quote headings if there's no code to insert]
+--stdin     (-s): Read Stdin for the markdown file to parse.
 ```


### PR DESCRIPTION
Add Stdin as a way to provide a markdown to parse.
Target is no longer required if --stdin is true.
The generated markdown can be outputted on Stdout
if --output is not set and --stdin is true.

This update is to allow pulpMd to be used by another
tool without creating an intermediary markdown file.