### PR TITLE
Use NoIntraEmphasis extension

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -201,7 +201,7 @@ func (ci *codeInj) Parse() *bf.Node {
 			ci.extensions = nil
 		}
 	}
-	ci.mdExt = bf.FencedCode | bf.Tables | bf.HeadingIDs
+	ci.mdExt = bf.FencedCode | bf.Tables | bf.HeadingIDs | bf.NoIntraEmphasis
 	return bf.New(bf.WithExtensions(ci.mdExt)).Parse(f)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,5 @@ require (
 	github.com/stretchr/testify v1.2.2 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
To prevent foo_bar_baz being interpreted like `foo<i>bar</i>baz`